### PR TITLE
Улучшен Dockerfile, добавлены инструкции для запуска через Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,10 @@
+FROM maven:3.8.4-jdk-11-slim as build
+COPY src /home/app/src
+COPY pom.xml /home/app
+RUN mvn -f /home/app/pom.xml clean package
+
+
 FROM amazoncorretto:11-alpine-jdk
-COPY target/*.jar document-flow.jar
+COPY --from=build /home/app/target/*.jar document-flow.jar
+EXPOSE 8080
 ENTRYPOINT ["java","-jar","/document-flow.jar"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,37 @@
+
+
+## Запуск через Docker
+
+---
+
+Для Windows: 
+1. скачать и установить [Docker Desktop](https://www.docker.com/products/docker-desktop/)
+2. Запустить Docker Desktop
+
+Для Linux:
+1. Скачать последний релиз [Docker Compose](https://github.com/docker/compose/releases)
+2. Установить Docker Compose:
+```bash
+# Add Docker's official GPG key:
+sudo apt-get update
+sudo apt-get install ca-certificates curl gnupg
+sudo install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+sudo chmod a+r /etc/apt/keyrings/docker.gpg
+
+# Add the repository to Apt sources:
+echo \
+  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
+  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install docker-compose
+```
+
+Для запуска проекта необходимо выполнить команду:
+```bash
+docker-compose up
+```
+Команда должна быть выполнена в корневой директории проекта (там, где находится файл docker-compose.yml)
+
+В **IntelliJ IDEA** для запуска необходимо нажать по файлу Dockerfile правой кнопкой мыши и выбрать пункт `Run 'Dockerfile'`

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt-get update
-sudo apt-get install docker-compose
+sudo apt-get install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin  docker-compose
 ```
 
 Для запуска проекта необходимо выполнить команду:


### PR DESCRIPTION
Инструкция для запуска через Docker добавлена в [README.md](https://github.com/Toolll1/document-flow/tree/Docker#%D0%B7%D0%B0%D0%BF%D1%83%D1%81%D0%BA-%D1%87%D0%B5%D1%80%D0%B5%D0%B7-docker) Запуск занимает некоторое время (от 60 до 400 секунд) так как maven скачивает все библиотеки. Было бы здорово добавить кэширование. Что-то похожее реализовано [тут](https://blog.frankel.ch/faster-maven-builds/2/). 